### PR TITLE
Send 404 when not found user

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,25 +28,25 @@ const get = (username, size) => {
 
 app.get("/:user", async (req, res, next) => {
   const result = await get(req.params.user, "_200x200");
-  if (!result) return next(404);
+  if (!result) return res.status(404).send('Not Found');
   request(result).pipe(res);
 });
 
 app.get("/:user/big", async (req, res, next) => {
   const result = await get(req.params.user, "_400x400");
-  if (!result) return next(404);
+  if (!result) return res.status(404).send('Not Found');
   request(result).pipe(res);
 });
 
 app.get("/:user/full", async (req, res, next) => {
   const result = await get(req.params.user, "");
-  if (!result) return next(404);
+  if (!result) return res.status(404).send('Not Found');
   request(result).pipe(res);
 });
 
 app.get("/:user/mini", async (req, res, next) => {
   const result = await get(req.params.user, "_mini");
-  if (!result) return next(404);
+  if (!result) return res.status(404).send('Not Found');
   request(result).pipe(res);
 });
 


### PR DESCRIPTION
Currently if provided a not found user, the servers returns "500 Internal Server Error" in production mode.

This changes propose to fix this, returning the 404 in all environments.